### PR TITLE
Fix cbor parsing bug

### DIFF
--- a/src/cbor.rs
+++ b/src/cbor.rs
@@ -415,7 +415,7 @@ impl OptionsInfo {
                 "clientPin" => options.client_pin = Some(decoder.bool()?),
                 "up" => options.up = decoder.bool()?,
                 "uv" => options.uv = Some(decoder.bool()?),
-                _ => continue,
+                _ => { decoder.bool()?; },
             }
         }
         Ok(options)


### PR DESCRIPTION
Previously, when options were parsed, the corresponding values were not
being consumed if they were not one of the recognized strings.
Authenticators may provide additional options, in which case the value
should be consumed and ignored. Otherwise, an error will be thrown
because the decoder encounters a boolean instead of the next integer key
of the map.

This small patch fixes this bug.